### PR TITLE
Copying metadata received from APIM

### DIFF
--- a/consumerorg/src/Service/ConsumerOrgService.php
+++ b/consumerorg/src/Service/ConsumerOrgService.php
@@ -1995,7 +1995,7 @@ class ConsumerOrgService {
       $customFields = $this->getCustomFields();
       foreach ($customFields as $field) {
         if (isset($json['consumer_org']['metadata'][$field])) {
-          $org->addCustomField($field, json_decode($json['consumer_org']['metadata'][$field], TRUE, 512, JSON_THROW_ON_ERROR));
+          $org->addCustomField($field, $json['consumer_org']['metadata'][$field]);
         }
       }
       $roles = [];


### PR DESCRIPTION
Metadata received from APIM is a string and doesn't have to be
decoded as a JSON object/primitive.

If some string that is not a JSON primitive is received, the function
fails so we need to remove JSON decoding.

See issue:
https://github.com/ibm-apiconnect/devportal/issues/36